### PR TITLE
Add CryptoAML.ai (free wallet AML / OFAC sanctions risk check)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ A collection of resources useful for OSINT Investigations on Cryptocurrencies an
 | [Vivigle](https://vivigle.com/) | A global cryptoRatings and Analytics Platform |
 | [Walletlabels](https://www.walletlabels.xyz/) | Search engine based on a collection of more than 7.5M ETH labeled addresses | 
 | [Dune](https://dune.com/browse/dashboards) | A community driven dashboards collection, useful for exploring ETH, TOKENS and NFT | 
+| [CryptoAML.ai](https://cryptoaml.ai) | A free crypto wallet AML / OFAC sanctions risk check, no signup required. It supports 30+ chains and is also available as a Telegram bot (@scorechain_amlbot) |
 
 ### ETH Other
 | Link | Description |

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ A collection of resources useful for OSINT Investigations on Cryptocurrencies an
 | [Vivigle](https://vivigle.com/) | A global cryptoRatings and Analytics Platform |
 | [Walletlabels](https://www.walletlabels.xyz/) | Search engine based on a collection of more than 7.5M ETH labeled addresses | 
 | [Dune](https://dune.com/browse/dashboards) | A community driven dashboards collection, useful for exploring ETH, TOKENS and NFT | 
-| [CryptoAML.ai](https://cryptoaml.ai) | A free crypto wallet AML / OFAC sanctions risk check, no signup required. It supports 30+ chains and is also available as a Telegram bot (@scorechain_amlbot) |
+| [CryptoAML.ai](https://cryptoaml.ai) | A free crypto wallet AML / OFAC sanctions risk check, no signup required. It supports 30+ chains and is also available as a Telegram bot (@cryptoamlscan_bot) |
 
 ### ETH Other
 | Link | Description |


### PR DESCRIPTION
Adds one entry to **ETH Blockchain Databases and Analyzers**.

[CryptoAML.ai](https://cryptoaml.ai) is a free crypto wallet AML / OFAC sanctions risk checker. You paste a wallet address and get a sanctions / risk score, no signup needed for the basic check. It covers 30+ chains and is also available as a Telegram bot (@scorechain_amlbot).

It fits alongside the existing address-risk / blacklist tools in that section (CryptoBlacklist, Chainabuse, etc.) and is useful for quickly screening an address during an investigation. One entry only, no other changes.